### PR TITLE
ImfMisc.h: Fixed missing <cstdint> include

### DIFF
--- a/OpenEXR/IlmImf/ImfMisc.h
+++ b/OpenEXR/IlmImf/ImfMisc.h
@@ -51,6 +51,7 @@
 #include "ImfForward.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 


### PR DESCRIPTION
References to `uintptr_t` caused compilation failure.

(somewhat of a duplicate of #1 that I had not seen previously...)